### PR TITLE
Fix Minor Markdown Syntax Problem In Comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ fn spawn_in_pool(jobs: Arc<Mutex<Receiver<Thunk<'static>>>>) {
 /// A scoped thread pool used to execute functions in parallel.
 ///
 /// `ScopedPool` is different from `TaskPool` in that:
+///
 /// * When dropped, it propagates panics that occur in the worker threads.
 /// * It doesn't require the `'static` bound on the functions that are executed.
 /// * Worker threads are joined when the `ScopedPool` is dropped.


### PR DESCRIPTION
Adds newline before list of ScopedPool differences so rustdoc will render a list and not append it to the previous paragraph.

You can currently see the problem in the second paragraph on http://doc.rust-lang.org/threadpool/threadpool/struct.ScopedPool.html