### PR TITLE
Hide `ScopedPool` behind a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ documentation = "http://doc.rust-lang.org/threadpool"
 description = """
 A thread pool for running a number of jobs on a fixed set of worker threads.
 """
+
+[features]
+scoped-pool = []


### PR DESCRIPTION
`thread::Scoped` has been marked unstable due to a memory safety hole.

r? @alexcrichton 