### PR TITLE
Make ThreadPool cloneable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ impl<'a> Drop for Sentinel<'a> {
 ///
 /// assert_eq!(rx.iter().take(8).fold(0, |a, b| a + b), 28);
 /// ```
+#[derive(Clone)]
 pub struct ThreadPool {
     // How the threadpool communicates with subthreads.
     //


### PR DESCRIPTION
A ThreadPool is really a handle to a thread pool.
This patch makes it possible to clone the ThreadPool object
and use it from multiple threads to start more threads.